### PR TITLE
Add option to configure json-bigint library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 TCF JavaScript library support both client and server (nodejs) configuration.
 
-## Disclaimer 
-This package is under heavy development and not ready for production. 
+## Disclaimer
+This package is under heavy development and not ready for production.
 API compatibility is not guaranteed.
 
 ### Install
@@ -178,10 +178,10 @@ c.svc.ProcessesV1.getChildren ("", false)
 });
 ```
 
-Note: special case to call tcf api with 64 argument value
+Note: special case to call tcf api with 64bits or floating point argument values
 
 ```js
-var JSONBig = require ('json-bigint'); 
+var JSONBig = require ('json-bigint');
 
 val = '9223372036351367728';
 client.svc.Memory.get("P3896", JSONbig.parse(val), 1, 672, 3)
@@ -192,6 +192,13 @@ client.svc.Memory.get("P3896", JSONbig.parse(val), 1, 672, 3)
     // Error
 });
 
+```
+
+By default, 64bits or floating point argument values are received from the TCL library
+as strings that can be manipulated with the package 'json-bigint'. The TCL library
+can be configured to return BigNumber objects instead (as defined by the 'bignumber.js' library):
+```js
+var tcf = require('tcf')({bigNumAsString: false});
 ```
 
 ### Legal Notices

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,5 +1,5 @@
 /**
- * TCF Channel inteface 
+ * TCF Channel inteface
  * @module tcf/channel
  * @license
  * Copyright (c) 2016 Wind River Systems
@@ -30,7 +30,6 @@ if (typeof global !== 'undefined') {
 
 var promise = Promise;
 var utils = require('./utils.js');
-var JSONbig = require('json-bigint');
 
 var channelId = 0;
 
@@ -65,8 +64,8 @@ var MARKER_EOS = -2;
 var OBUF_SIZE = 1024 * 128;
 
 /**
- * @class 
- * @param {Protocol} protocol - definition of local services 
+ * @class
+ * @param {Protocol} protocol - definition of local services
  */
 function Channel(protocol) {
     var ibuf;
@@ -86,6 +85,9 @@ function Channel(protocol) {
     var hasZeroCopySupport = false;
 
     setProtocol(protocol);
+
+    var options = require('./options.js').get();
+    var JSONbig = require('json-bigint')({storeAsString: options.bigNumAsString});
 
     var enableZeroCopy = function(enable) {
         hasZeroCopySupport = enable;
@@ -129,7 +131,7 @@ function Channel(protocol) {
         });
         return pres;
     };
-    
+
     var writeStream = function(ch) {
         utils.assert(owrite < obuf.length);
         if (ch == MARKER_EOM) {
@@ -333,7 +335,7 @@ function Channel(protocol) {
                 writeStream(MARKER_EOM);
             })
             .catch(function(err) {
-                // close the channel 
+                // close the channel
                 console.log ('TCF protocol Error', err);
             });
         }
@@ -380,7 +382,7 @@ function Channel(protocol) {
                 var eargsParsers = evhandler.parsers; // proto.getEventArgsParsers(msg.service, msg.name);
                 var eargs = [];
                 var ev_idx = 0;
-                
+
                 while (peekStream() != MARKER_EOM) {
                     if (eargsParsers[ev_idx] === 'binary') {
                         eargs.push(atob(JSONbig.parse(readStringz())));
@@ -554,7 +556,7 @@ function Channel(protocol) {
             if (state === ChannelState.Disconnected) return;
 
             writeStream(MARKER_EOS);
-            writeErrorObject(null);
+            writeStringz("null");
             writeStream(MARKER_EOM);
 
             state = ChannelState.Disconnected;
@@ -578,7 +580,7 @@ function Channel(protocol) {
                 service: service,
                 name: name,
                 parsers: parsers || [],
-                handler: eh                
+                handler: eh
             });
         },
         getState: function() {

--- a/src/tcf.js
+++ b/src/tcf.js
@@ -29,18 +29,36 @@
  */
 
 /**
- * @typedef {string} PeerUrl - string representing a peer url. 
- * @example "WS::8080" server running on localhost on port 8080 (all interfaces) 
- * @example "TCP::9000" server running on localhost on port 900 (all interfaces) 
- * @example "WSS:192.168.1.1:443" 
+ * @typedef {string} PeerUrl - string representing a peer url.
+ * @example "WS::8080" server running on localhost on port 8080 (all interfaces)
+ * @example "TCP::9000" server running on localhost on port 900 (all interfaces)
+ * @example "WSS:192.168.1.1:443"
  * @example "wss://192.168.1.1/"
  */
 
 /* global exports */
+
 require('./transports.js');
-exports.Client = require('./client.js').Client;
-exports.Service = require('./service.js').Service;
-exports.Protocol = require('./protocol.js').Protocol;
-exports.schemas = require('./schemas.js').schemas;
-exports.BroadcastGroup = require('./broadcast.js').BroadcastGroup;
-exports.Server = require('./server.js').Server;
+
+module.exports = function(options) {
+
+    require('./options').set(options);
+
+    return  {
+        Client: require('./client.js').Client,
+        Service: require('./service.js').Service,
+        Protocol: require('./protocol.js').Protocol,
+        schemas: require('./schemas.js').schemas,
+        BroadcastGroup: require('./broadcast.js').BroadcastGroup,
+        Server: require('./server.js').Server
+    };
+};
+
+// create the default method members with no options applied for backwards compatibility
+
+module.exports.Client = require('./client.js').Client;
+module.exports.Service = require('./service.js').Service;
+module.exports.Protocol = require('./protocol.js').Protocol;
+module.exports.schemas = require('./schemas.js').schemas;
+module.exports.BroadcastGroup = require('./broadcast.js').BroadcastGroup;
+module.exports.Server = require('./server.js').Server;

--- a/test/client.js
+++ b/test/client.js
@@ -60,18 +60,18 @@ describe('tcf-client', function () {
             if (!args) throw {msg:'Invalid argument'};
             return ([{error:"this is an error object"}]);
         });
-        
+
         /* test service ping */
         server = new tcf.Server(wsurl, protocol);
     });
-    
+
     it('Server Connection', function () {
         return new Promise((resolve, reject) => {
             var client = new tcf.Client();
-            client.connect(wsurl, 
+            client.connect(wsurl,
                 () => {
                     expect(client).to.have.property('svc');
-                    client.close(); 
+                    client.close();
                     resolve();
                 },
                 () => {reject("channel Closed");},
@@ -82,31 +82,27 @@ describe('tcf-client', function () {
 
     it('Server Connection without server', function (done) {
         var client = new tcf.Client();
-        
-        client.connect('WS::20002', 
-            () => {done('channel conected');},
+
+        client.connect('WS::20002',
+            () => {done('channel connected');},
             () => {done("channel Closed");},
             () => {done();}
         );
     });
 
-    it('Should rise invalid peer url error', function () {
-        var fn = function () {
-            new tcf.Client().connect();
-        };
-        expect(fn).to.throw(Error, 'Invalid peer url');
+    it('Should return -1 for invalid peer url', function () {
+        var client = new tcf.Client();
 
-        fn = function () {
-            new tcf.Client().connect('');
-        };
-        return expect(fn).to.throw(Error, 'Invalid peer url');
+        expect(client.connect()).to.equal(-1);
+
+        return expect(client.connect('')).to.equal(-1);
     });
-    
+
     it('Send command echo - should return 2 args', function () {
         return new Promise ((resolve, reject) => {
             var client = new tcf.Client();
-            
-            client.connect(wsurl, 
+
+            client.connect(wsurl,
                 () => {
                     client.sendCommand('Pong', 'echo',['testmsg'])
                     .then((res) => {
@@ -114,7 +110,7 @@ describe('tcf-client', function () {
                         res[0].should.equal(0);
                         res[1].should.equal('testmsg');
                         resolve();
-                        client.close(); 
+                        client.close();
                     })
                     .catch(err => {reject(err)})
                 },
@@ -123,19 +119,19 @@ describe('tcf-client', function () {
                 );
         });
     });
-    
+
     it('Send command error - should return 1 arg (error)', function () {
         return new Promise ((resolve, reject) => {
             var client = new tcf.Client();
-            
-            client.connect(wsurl, 
+
+            client.connect(wsurl,
                 () => {
                     client.sendCommand('Pong', 'error',['testmsg'])
                     .then((res) => {
                         res.should.have.length(1);
                         res[0].should.not.equal(0);
                         resolve();
-                        client.close(); 
+                        client.close();
                     })
                     .catch(err => {reject(err)})
                 },


### PR DESCRIPTION
Add an option to TCF module to change the default encoding option
of the json-bigint library.
By default, TCF output bigint as string.