### PR TITLE
Add definition of proxy interface when creating a client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcf",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Javascript TCF client/server library.",
   "main": "src/tcf.js",
   "browser": {
@@ -39,6 +39,6 @@
     "postinstall": "bower install",
     "build": "mkdir -p dist && browserify src/tcf.js -s tcf -i atob -i btoa -i ./src/server.js -i ./src/channel_server_ws.js > dist/tcf.js",
     "test": " ./node_modules/.bin/mocha --reporter spec --full-trace test/**/*.js",
-    "doc": "./node_modules/.bin/jsdoc -r src/tcf.js src/channel.js src/protocol.js src/client.js src/server.js -R ./README.md -d ./doc/"
+    "doc": "./node_modules/.bin/jsdoc src/tcf.js src/channel.js src/protocol.js src/client.js src/server.js src/services/interfaces.js -R ./README.md -d ./doc/"
   }
 }

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,6 +1,5 @@
 /**
  * TCF Channel inteface
- * @module tcf/channel
  * @license
  * Copyright (c) 2016 Wind River Systems
  *
@@ -63,10 +62,19 @@ var MARKER_EOM = -1;
 var MARKER_EOS = -2;
 var OBUF_SIZE = 1024 * 128;
 
+
 /**
+ * TCF channel
+ * @typedef {Object} Channel
+ */
+
+/*
+ * TCF channel
+ *
  * @class
  * @param {Protocol} protocol - definition of local services
  */
+
 function Channel(protocol) {
     var ibuf;
     var iread = 0;
@@ -314,6 +322,7 @@ function Channel(protocol) {
             var name = readStringz();
             var args = [];
             var cargsParsers = proto.getCommandArgsParsers(svc, name);
+            var res_idx = 0;
 
             /* parse arguments */
             while ((ch = peekStream()) != MARKER_EOM) {
@@ -321,6 +330,7 @@ function Channel(protocol) {
                     args.push(btoa(JSONbig.parse(readStringz())));
                 }
                 else args.push(JSONbig.parse(readStringz()));
+                res_idx++;
             }
 
             readStream(); //flush EOM
@@ -345,7 +355,7 @@ function Channel(protocol) {
             // get the reply handler
             var rh = popReplyHandler(msg.token);
             msg.res = {};
-            var res_idx = 0;
+            res_idx = 0;
             // build the result object
             while ((ch = peekStream()) != MARKER_EOM) {
                 if (ch === 0) {

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -1,6 +1,5 @@
 /**
- * TCF Protocol interface 
- * @module tcf/protocol
+ * TCF Protocol interface
  * @license
  * Copyright (c) 2016 Wind River Systems
  *
@@ -24,24 +23,25 @@
  */
 
 /**
- * Protocol object holds the various command and events handlers implemented by 
+ * Protocol object holds the various command and events handlers implemented by
  * the peer.
- * 
- * @class 
+ *
+ * @class
  */
-var Protocol = function () {
+
+function Protocol() {
     this._svc = {};
     this._ev = {};
     this._svcList = [];
-};
+}
 
 /**
  * @typedef {function} CmdHandler
  * @param {Channel} c - channel requesting the command
  * @param {TcfArg_t[]}  args - array of command arguments
- * @returns {Promise|TcfArg_t[]} returns either a Promise that will be resolved 
+ * @returns {Promise|TcfArg_t[]} returns either a Promise that will be resolved
  * to a list of respose arguments or the list of response arguments
- * @throws {ProtocolError} - if arguments fail to comply to service spec. 
+ * @throws {ProtocolError} - if arguments fail to comply to service spec.
  * Note that protocol errors leads to immediate termination of the channel
  */
 
@@ -50,14 +50,14 @@ var Protocol = function () {
  * @param {Channel} c - channel sending the event
  * @param {TcfArg_t[]}  args - array of event arguments
  */
- 
+
 /**
  * Add a command handler
  * @param {string} svc - name of the service
  * @param {string} cmd - command name
  * @param {CmdHandler} ch - callback for handling the command
  * @param {string[]}  [parsers = [...'json']] - list of command argument parsers
- * 
+ *
  */
 Protocol.prototype.addCommandHandler = function(svc, cmd, ch, parsers) {
     if( !this._svc[svc] ) this._svc[svc] = {};
@@ -91,6 +91,7 @@ Protocol.prototype.getCommandArgsParsers = function (svc, cmd) {
 Protocol.prototype.getServiceList = function () {
     return this._svcList;
 };
+
 
 exports.Protocol = Protocol;
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,6 @@
-/**
- * Implementation of a TCF server 
- * @module tcf/server
- * @license
+/*
+ * Implementation of a TCF server
+ *
  * Copyright (c) 2016 Wind River Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -57,14 +56,15 @@ function channelServer(ps) {
 
 /**
  * Creates a new tcf server.
- * a tcf client is a channel and the corresponding set of tcf remote services 
+ * a tcf client is a channel and the corresponding set of tcf remote services
  * proxies.
- * 
- * @class 
+ *
+ * @class
  * @param {PeerUrl} url - Defines the url of the server
- * @param {Protocol} protocol - definition of server side services 
+ * @param {Protocol} protocol - definition of server side services
  * @param {object} [options] - additionnal options
  */
+
 function Server(url, protocol, options) {
 
     this.ps = peer.peer_from_url(url);

--- a/src/services/interfaces.js
+++ b/src/services/interfaces.js
@@ -1,4 +1,6 @@
-/**
+/*
+ * TCF Proxy interface
+ *
  * Copyright (c) 2016-2017 Wind River Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 var utils = require('../utils.js');
+
+/**
+ * Command definition.
+ * @typedef {Object} CommandDef
+ * @property {string} name - Command name.
+ * @property {ParameterType[]} args - Command arguments definition.
+ * @property {ParameterType[]} results - Command results definition.
+ */
+
+/**
+ * Parameter type.
+ * @typedef {Object} ParameterType
+ * @property {string} [title] - Parameter access name.
+ * @property {string} type - Parameter type: 'object', 'binary', 'array', 'string', 'boolean', 'integer'.
+ */
 
 var services = {
     Expressions: require('./interfaces/expressions.js'),
@@ -42,15 +60,47 @@ var services = {
 
 function addService(prototype) {
     utils.assert (!services[prototype.name]);
-    services[prototype.name] = prototype;    
+    services[prototype.name] = prototype;
 };
 
 function removeService(name) {
-    delete services[name];    
+    delete services[name];
+}
+
+/**
+ * Creates a new service proxy interface
+ *
+ * @class
+ * @param {string} arg - Opensource service name
+ * @param {Object} arg - Service interface definition
+ * @param {string} arg.name - service name
+ * @param {CommandDef[]} [arg.cmds] - commands definitions
+ * @param {Object[]} [arg.evs] - events definition
+ */
+
+function Interface(arg) {
+
+    if (typeof arg !== 'string' && typeof arg !== 'object') {
+        throw new Error('Invalid argument ' + arg + ' for Interface constructor');
+    }
+
+    if (typeof arg === 'string') {
+        // args is one of the opensource interface name
+        var itf = services[arg];
+        if (!itf) throw new Error('Interface ' + arg + ' is not supported');
+        Object.assign(this, itf);
+    }
+    else {
+        if (!arg.name) throw new Error('Invalid interface object: missing name property');
+        this.name = arg.name;
+        this.cmds = arg.cmds || [];
+        this.evs = arg.evs || [];
+    }
 }
 
 module.exports = {
     services : services,
     addService: addService,
     removeService: removeService,
+    Interface: Interface
 };

--- a/src/tcf.js
+++ b/src/tcf.js
@@ -1,6 +1,5 @@
 /**
  * Top level TCF library module
- * @module tcf
  * @license
  * Copyright (c) 2016 Wind River Systems.
  *
@@ -24,11 +23,13 @@
  */
 
 /**
+ * @global
  * @typedef {boolean|number|string|Object|Uint8Array} TcfArg_t - Defines the
  * different types of arguments for TCF commands, Events, or Response handling
  */
 
 /**
+ * @global
  * @typedef {string} PeerUrl - string representing a peer url.
  * @example "WS::8080" server running on localhost on port 8080 (all interfaces)
  * @example "TCP::9000" server running on localhost on port 900 (all interfaces)
@@ -50,7 +51,8 @@ module.exports = function(options) {
         Protocol: require('./protocol.js').Protocol,
         schemas: require('./schemas.js').schemas,
         BroadcastGroup: require('./broadcast.js').BroadcastGroup,
-        Server: require('./server.js').Server
+        Server: require('./server.js').Server,
+        Interface: require('./services/interfaces.js').Interface
     };
 };
 
@@ -62,3 +64,4 @@ module.exports.Protocol = require('./protocol.js').Protocol;
 module.exports.schemas = require('./schemas.js').schemas;
 module.exports.BroadcastGroup = require('./broadcast.js').BroadcastGroup;
 module.exports.Server = require('./server.js').Server;
+module.exports.Interface = require('./services/interfaces.js').Interface;

--- a/test/client.js
+++ b/test/client.js
@@ -140,4 +140,38 @@ describe('tcf-client', function () {
                 );
         });
     });
+
+
+    it('Define a client with a Pong service proxy interface', function () {
+        return new Promise ((resolve, reject) => {
+
+            var itf = new tcf.Interface({
+                name: 'Pong',
+                cmds: [{
+                    name: 'echo',
+                    args: [{type: 'string'}],
+                    results: [{title: 'err', type: 'number'}, {title: 'msg', type: 'string'}],
+                }]
+            });
+
+            var client = new tcf.Client([itf]);
+
+            client.connect(wsurl,
+                () => {
+                    client.svc['Pong'].echo('testmsg')
+                    .then((res) => {
+                        res.should.have.all.keys(['err', 'msg']);
+                        res.err.should.equal(0);
+                        res.msg.should.equal('testmsg');
+                        resolve();
+                        client.close();
+                    })
+                    .catch(err => {reject(err)});
+                },
+                () => {reject("channel Closed");},
+                () => {reject("channel Error");}
+                );
+        });
+    });
+
 });


### PR DESCRIPTION
Example of use:

var tcf = require('tcf');
// Define a custom interface
var itf1 = new tcf.Interface({
  name: 'Pong',
  cmds: [{
    name: 'echo',
    args: [{type: 'string'}],
    results: [{title: 'err', type: 'number'}, {title: 'msg', type: 'string'}],
  }]
});
// Use an opensource interface
var itf2 = new tcf.Interface('Terminals');

var client = new tcf.Client([itfi1, itf2]);