### PR TITLE
ignore missing bower at postinstall or install will fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "xunit-file": "^0.0.7"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "bower install || echo no bower",
     "build": "mkdir -p dist && browserify src/tcf.js -s tcf -i atob -i btoa -i ./src/server.js -i ./src/channel_server_ws.js > dist/tcf.js",
     "test": " ./node_modules/.bin/mocha --reporter spec --full-trace test/**/*.js",
     "doc": "./node_modules/.bin/jsdoc src/tcf.js src/channel.js src/protocol.js src/client.js src/server.js src/services/interfaces.js -R ./README.md -d ./doc/"


### PR DESCRIPTION
We have no bower in our toolchain and use it with nodejs only.